### PR TITLE
[Misc] Add CODEOWNERS File

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @anabrunner @befunger @CorreyL @CSTSTEVENU @garenpham @immangat @nam-m @openBC-ca @PooriaT @SamHuo213


### PR DESCRIPTION
## Description

This PR adds a `CODEOWNERS` file, following the GitHub documentation here:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

More specifically, following the code block example syntax here:

```
# These owners will be the default owners for everything in
# the repo. Unless a later match takes precedence,
# @global-owner1 and @global-owner2 will be requested for
# review when someone opens a pull request.
*       @global-owner1 @global-owner2
```

Per @SamHuo213, I've added all existing members of the OpenBCca organization as code owners.