### PR TITLE
Add Axios and Github API tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
   },
   root: true,
-  "ignorePatterns": [".eslintrc.cjs"],
+  ignorePatterns: ['.eslintrc.cjs'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,7 +10,6 @@ const createJestConfig = nextJest({
 const config = {
   // Add more setup options before each test is run
   testEnvironment: 'jest-environment-jsdom',
-  preset: 'ts-jest',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,12 @@
         "@types/node": "20.9.2",
         "@types/react": "18.2.37",
         "@types/react-dom": "18.2.15",
-        "axios-mock-adapter": "^1.22.0",
         "eslint": "8.54.0",
         "eslint-config-next": "14.0.3",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "ts-jest": "^29.1.1",
         "typescript": "5.2.2"
       }
     },
@@ -2788,19 +2786,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios-mock-adapter": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
-      "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "is-buffer": "^2.0.5"
-      },
-      "peerDependencies": {
-        "axios": ">= 0.17.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -3016,18 +3001,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -5070,29 +5043,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -6652,12 +6602,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6708,12 +6652,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -8398,61 +8336,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-jest": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
-      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
-      "dev": true,
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^29.0.0",
-        "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "20.9.2",
         "@types/react": "18.2.37",
         "@types/react-dom": "18.2.15",
+        "axios-mock-adapter": "^1.22.0",
         "eslint": "8.54.0",
         "eslint-config-next": "14.0.3",
         "eslint-config-prettier": "^9.0.0",
@@ -2787,6 +2788,19 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
+      "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -5054,6 +5068,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-callable": {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,12 @@
     "@types/node": "20.9.2",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
-    "axios-mock-adapter": "^1.22.0",
     "eslint": "8.54.0",
     "eslint-config-next": "14.0.3",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "ts-jest": "^29.1.1",
     "typescript": "5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "20.9.2",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
+    "axios-mock-adapter": "^1.22.0",
     "eslint": "8.54.0",
     "eslint-config-next": "14.0.3",
     "eslint-config-prettier": "^9.0.0",

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {
   axiosConfig,
@@ -8,35 +8,33 @@ import {
 
 describe('Mock Axios', () => {
   let axiosMock: MockAdapter;
-  let mockResponse: AxiosResponse | object | null;
-
   const accessToken = process.env.GITHUB_API_KEY;
 
+  // Set new axios mock before each test
   beforeEach(() => {
     axiosMock = new MockAdapter(axios);
   });
 
+  // Remove axios mockafter each test
   afterEach(() => {
     axiosMock.restore();
-    mockResponse = null;
   });
 
-  it('should get axios config', async () => {
-    mockResponse = { data: 'mocked data' };
+  it('should return an Axios instance', async () => {
     axiosMock
       .onGet('https://api.github.com/test-endpoint')
-      .reply(200, mockResponse);
+      .reply(200, { data: 'mocked data' });
 
     const axiosInstance = axiosConfig();
 
     return axiosInstance.get('/test-endpoint').then((response) => {
       expect(response.status).toBe(200);
-      expect(response.data).toEqual(mockResponse);
+      expect(response.data).toEqual({ data: 'mocked data' });
     });
   });
 
   describe('Github API calls', () => {
-    mockResponse = {
+    const mockResponse = {
       data: [{ name: 'openbc-web' }],
       baseURL: 'https://api.github.com',
       headers: {

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -22,10 +22,12 @@ describe('Github client service test', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.GITHUB_API_KEY = 'testToken';
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    delete process.env.GITHUB_API_KEY;
   });
 
   describe('axiosConfig', () => {

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -36,6 +36,24 @@ describe('Github client service test', () => {
 
       expect(axiosInstance).toEqual(mockResponse);
     });
+
+    it('should throw error if Github access token is not provided', () => {
+      process.env.GITHUB_API_KEY = undefined;
+      axios.create = jest.fn().mockReturnValue(mockResponse);
+      try {
+        getAxiosInstance();
+      } catch (error) {
+        let message;
+        // Specify message only when error type is defined as Error
+        if (error instanceof Error) {
+          message = error.message;
+        } else {
+          message = String(error);
+        }
+
+        expect(message).toBe('GitHub access token is not provided.');
+      }
+    });
   });
 
   describe('getRepositoryList', () => {

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -1,22 +1,21 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import {
   getAxiosInstance,
-  getRepositoryList,
   getRepositoryInformation,
+  getRepositoryList,
 } from '../client-services/github.client-service';
 
 jest.mock('axios');
 
 describe('Github client service test', () => {
   const accessToken = 'testToken';
-  const mockResponse: AxiosResponse = {
+  const mockResponse = {
     data: [{ name: 'openbc-web' }],
     headers: {
       Authorization: `token ${accessToken}`,
       'Content-Type': 'application/json',
     },
     config: {},
-    headers: {},
     request: {},
   };
   const originalEnv = process.env;
@@ -31,9 +30,9 @@ describe('Github client service test', () => {
   });
 
   describe('getAxiosInstance', () => {
-    it('should return an Axios instance', async () => {
-      axios.create.mockResolvedValueOnce(mockResponse);
-      const axiosInstance: AxiosInstance = await getAxiosInstance();
+    it('should return an Axios instance', () => {
+      axios.create = jest.fn().mockReturnValue(mockResponse);
+      const axiosInstance: AxiosInstance = getAxiosInstance();
 
       expect(axiosInstance).toEqual(mockResponse);
     });
@@ -41,7 +40,7 @@ describe('Github client service test', () => {
 
   describe('getRepositoryList', () => {
     it('should get the list of repositories', async () => {
-      axios.create.mockReturnValueOnce({
+      axios.create = jest.fn().mockReturnValue({
         get: jest.fn().mockResolvedValueOnce(mockResponse),
       });
       const reposListResponse: AxiosResponse = await getRepositoryList();
@@ -55,7 +54,7 @@ describe('Github client service test', () => {
       const repositoryName = 'openbc-web';
       const parameter = '';
 
-      axios.create.mockReturnValueOnce({
+      axios.create = jest.fn().mockReturnValue({
         get: jest.fn().mockResolvedValueOnce(mockResponse),
       });
       const testRepoResponse: AxiosResponse = await getRepositoryInformation(

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -8,7 +8,7 @@ import {
 
 describe('Mock Axios', () => {
   let axiosMock: MockAdapter;
-  const accessToken = process.env.GITHUB_API_KEY;
+  const accessToken = 'testToken';
 
   // Set new axios mock before each test
   beforeEach(() => {

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -15,7 +15,7 @@ describe('Mock Axios', () => {
     axiosMock = new MockAdapter(axios);
   });
 
-  // Remove axios mockafter each test
+  // Remove axios mock after each test
   afterEach(() => {
     axiosMock.restore();
   });

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -1,8 +1,8 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import {
-  axiosConfig,
-  getReposList,
-  getRepoInfo,
+  getAxiosInstance,
+  getRepositoryList,
+  getRepositoryInformation,
 } from '../client-services/github.client-service';
 
 jest.mock('axios');
@@ -22,44 +22,42 @@ describe('Github client service test', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.GITHUB_API_KEY = 'testToken';
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
-    delete process.env.GITHUB_API_KEY;
   });
 
-  describe('axiosConfig', () => {
+  describe('getAxiosInstance', () => {
     it('should return an Axios instance', async () => {
       axios.create.mockResolvedValueOnce(mockResponse);
-      const axiosInstance: AxiosInstance = await axiosConfig();
+      const axiosInstance: AxiosInstance = await getAxiosInstance();
 
       expect(axiosInstance).toEqual(mockResponse);
     });
   });
 
-  describe('getReposList', () => {
+  describe('getRepositoryList', () => {
     it('should get the list of repositories', async () => {
       axios.create.mockReturnValueOnce({
         get: jest.fn().mockResolvedValueOnce(mockResponse),
       });
-      const reposListResponse: AxiosResponse = await getReposList();
+      const reposListResponse: AxiosResponse = await getRepositoryList();
 
       expect(reposListResponse).toEqual(mockResponse);
     });
   });
 
-  describe('getRepoInfo', () => {
+  describe('getRepositoryInformation', () => {
     it('should get openbc-web repo info', async () => {
-      const repoName = 'openbc-web';
+      const repositoryName = 'openbc-web';
       const parameter = '';
 
       axios.create.mockReturnValueOnce({
         get: jest.fn().mockResolvedValueOnce(mockResponse),
       });
-      const testRepoResponse: AxiosResponse = await getRepoInfo(
-        repoName,
+      const testRepoResponse: AxiosResponse = await getRepositoryInformation(
+        repositoryName,
         parameter
       );
 

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -1,0 +1,69 @@
+import axios, { AxiosResponse } from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {
+  axiosConfig,
+  getRepoInfo,
+  getReposList,
+} from '../client-services/github.client-service';
+
+describe('Mock Axios', () => {
+  let axiosMock: MockAdapter;
+  let mockResponse: AxiosResponse | object | null;
+
+  const accessToken = process.env.GITHUB_API_KEY;
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+    mockResponse = null;
+  });
+
+  it('should get axios config', async () => {
+    mockResponse = { data: 'mocked data' };
+    axiosMock
+      .onGet('https://api.github.com/test-endpoint')
+      .reply(200, mockResponse);
+
+    const axiosInstance = axiosConfig();
+
+    return axiosInstance.get('/test-endpoint').then((response) => {
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual(mockResponse);
+    });
+  });
+
+  describe('Github API calls', () => {
+    mockResponse = {
+      data: [{ name: 'openbc-web' }],
+      baseURL: 'https://api.github.com',
+      headers: {
+        Authorization: `token ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    };
+
+    it('should get the list of repositories', async () => {
+      axiosMock
+        .onGet('https://api.github.com/orgs/OpenBCca/repos')
+        .reply(200, mockResponse);
+      const reposListResponse = await getReposList();
+
+      expect(reposListResponse.data).toEqual(mockResponse);
+    });
+
+    it('should get openbc-web repo info', async () => {
+      const repoName = 'openbc-web';
+      const parameter = '';
+
+      axiosMock
+        .onGet(`https://api.github.com/repos/OpenBCca/${repoName}${parameter}`)
+        .reply(200, mockResponse);
+      const testRepoResponse = await getRepoInfo(repoName, parameter);
+
+      expect(testRepoResponse.data).toEqual(mockResponse);
+    });
+  });
+});

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import axios from 'axios';
 import {
   getAxiosInstance,
   getRepositoryInformation,
@@ -15,8 +15,6 @@ describe('Github client service test', () => {
       Authorization: `token ${accessToken}`,
       'Content-Type': 'application/json',
     },
-    config: {},
-    request: {},
   };
   const originalEnv = process.env;
 
@@ -32,7 +30,7 @@ describe('Github client service test', () => {
   describe('getAxiosInstance', () => {
     it('should return an Axios instance', () => {
       axios.create = jest.fn().mockReturnValue(mockResponse);
-      const axiosInstance: AxiosInstance = getAxiosInstance();
+      const axiosInstance = getAxiosInstance();
 
       expect(axiosInstance).toEqual(mockResponse);
     });
@@ -61,7 +59,7 @@ describe('Github client service test', () => {
       axios.create = jest.fn().mockReturnValue({
         get: jest.fn().mockResolvedValueOnce(mockResponse),
       });
-      const reposListResponse: AxiosResponse = await getRepositoryList();
+      const reposListResponse = await getRepositoryList();
 
       expect(reposListResponse).toEqual(mockResponse);
     });
@@ -75,7 +73,7 @@ describe('Github client service test', () => {
       axios.create = jest.fn().mockReturnValue({
         get: jest.fn().mockResolvedValueOnce(mockResponse),
       });
-      const testRepoResponse: AxiosResponse = await getRepositoryInformation(
+      const testRepoResponse = await getRepositoryInformation(
         repositoryName,
         parameter
       );

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -6,7 +6,12 @@ import {
   getReposList,
 } from '../client-services/github.client-service';
 
-describe('Mock Axios', () => {
+jest.mock('../client-services/github.client-service', () => ({
+  ...jest.requireActual('../client-services/github.client-service'),
+  axiosConfig: jest.fn(), // Mocking axiosConfig
+}));
+
+describe('Github client service test', () => {
   let axiosMock: MockAdapter;
   const accessToken = 'testToken';
 
@@ -20,16 +25,21 @@ describe('Mock Axios', () => {
     axiosMock.restore();
   });
 
-  it('should return an Axios instance', async () => {
+  it('should return an Axios instance', () => {
     axiosMock
       .onGet('https://api.github.com/test-endpoint')
       .reply(200, { data: 'mocked data' });
+
+    process.env.GITHUB_API_KEY = 'testToken';
+    (axiosConfig<jest.Mock>).mockReturnValue({
+      get: jest.fn().mockResolvedValue({ status: 200, data: 'mocked data' }),
+    });
 
     const axiosInstance = axiosConfig();
 
     return axiosInstance.get('/test-endpoint').then((response) => {
       expect(response.status).toBe(200);
-      expect(response.data).toEqual({ data: 'mocked data' });
+      expect(response.data).toEqual('mocked data');
     });
   });
 

--- a/src/client-services/github.client-service.test.tsx
+++ b/src/client-services/github.client-service.test.tsx
@@ -19,13 +19,15 @@ describe('Github client service test', () => {
     headers: {},
     request: {},
   };
+  const originalEnv = process.env;
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...originalEnv, GITHUB_API_KEY: 'testApiKey' };
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    process.env = originalEnv;
   });
 
   describe('getAxiosInstance', () => {

--- a/src/client-services/github.client-service.ts
+++ b/src/client-services/github.client-service.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 
-export function axiosConfig(): AxiosInstance {
+export function getAxiosInstance(): AxiosInstance {
   const accessToken: string | undefined = process.env.GITHUB_API_KEY;
 
   if (!accessToken) {
@@ -17,19 +17,19 @@ export function axiosConfig(): AxiosInstance {
   return axiosInstance;
 }
 
-export async function getReposList(): Promise<AxiosResponse> {
-  const response: AxiosResponse = await axiosConfig().get(
+export async function getRepositoryList(): Promise<AxiosResponse> {
+  const response: AxiosResponse = await getAxiosInstance().get(
     '/orgs/OpenBCca/repos'
   );
   return response;
 }
 
-export async function getRepoInfo(
-  repoName: string,
+export async function getRepositoryInformation(
+  repositoryName: string,
   parameter = ''
 ): Promise<AxiosResponse> {
-  const response = await axiosConfig().get(
-    `/repos/OpenBCca/${repoName}${parameter}`
+  const response = await getAxiosInstance().get(
+    `/repos/OpenBCca/${repositoryName}${parameter}`
   );
   return response;
 }

--- a/src/client-services/github.client-service.ts
+++ b/src/client-services/github.client-service.ts
@@ -1,9 +1,7 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
-import getConfig from 'next/config';
 
-function axiosConfig(): AxiosInstance {
-  const config = getConfig();
-  const accessToken: string | undefined = config.githubApiToken;
+export function axiosConfig(): AxiosInstance {
+  const accessToken: string | undefined = process.env.GITHUB_API_KEY;
 
   if (!accessToken) {
     throw new Error('GitHub access token is not provided.');
@@ -16,7 +14,6 @@ function axiosConfig(): AxiosInstance {
       'Content-Type': 'application/json',
     },
   });
-
   return axiosInstance;
 }
 


### PR DESCRIPTION
Added tests for
1. axiosConfig
2. getReposList()
3. getRepoInfo()

Pre-requisites:
- `mock-axios-adapter` package is installed to mock axios
- GITHUB_API_KEY is stored in `src/.env.test.local`, I changed this token retrieval method in `github.client-service.ts` to use `process.env` instead of `nextConfig`. 
Reference: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables