### PR TITLE
Remove inactive members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @CorreyL @CSTSTEVENU @garenpham @immangat @nam-m @openBC-ca @PooriaT @SamHuo213 @umsu2 @Unknown-0perator
+*       @CorreyL @CSTSTEVENU @immangat @nam-m @openBC-ca @PooriaT @SamHuo213 @umsu2 @Unknown-0perator

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @anabrunner @befunger @CorreyL @CSTSTEVENU @garenpham @immangat @nam-m @openBC-ca @PooriaT @SamHuo213 @umsu2 @Unknown-0perator
+*       @CorreyL @CSTSTEVENU @garenpham @immangat @nam-m @openBC-ca @PooriaT @SamHuo213 @umsu2 @Unknown-0perator


### PR DESCRIPTION
Fixes #88 

Per Sam's Discord message from Jan 25th 2024 here:

https://discord.com/channels/1144787722754588752/1144787723228561440/1200192248642551899

The following members should be removed from the GitHub Organization and CODEOWNER group:

- Ana (https://github.com/anabrunner)
- Tan (https://github.com/garenpham)
- Jacqueline (https://github.com/JSmith604)
- Alexander (https://github.com/befunger)